### PR TITLE
EDGAPIUTL-12: Upgrade jackson and all other dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,16 +12,16 @@
     <java.version>11</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <vault.version>5.1.0</vault.version>
-    <aws-java-sdk.version>1.12.218</aws-java-sdk.version>
+    <aws-java-sdk.version>1.12.341</aws-java-sdk.version>
     <httpcore.version>4.4.15</httpcore.version>
-    <versions-maven-plugin.version>2.10.0</versions-maven-plugin.version>
-    <maven-enforcer-plugin.version>3.0.0</maven-enforcer-plugin.version>
+    <versions-maven-plugin.version>2.13.0</versions-maven-plugin.version>
+    <maven-enforcer-plugin.version>3.1.0</maven-enforcer-plugin.version>
     <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
     <build-helper-maven-plugin.version>3.3.0</build-helper-maven-plugin.version>
-    <maven-release-plugin.version>3.0.0-M5</maven-release-plugin.version>
+    <maven-release-plugin.version>3.0.0-M7</maven-release-plugin.version>
     <awaitility.version>4.2.0</awaitility.version>
     <junit.version>4.13.2</junit.version>
-    <wiremock.version>2.33.2</wiremock.version>
+    <wiremock.version>2.35.0</wiremock.version>
     <mockito.version>4.5.1</mockito.version>
     <commons-lang3.version>3.12.0</commons-lang3.version>
   </properties>
@@ -31,14 +31,14 @@
       <dependency>
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
-        <version>2.13.3</version>
+        <version>2.14.0</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.17.2</version>
+        <version>2.19.0</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -196,7 +196,7 @@
 
       <plugin>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.2.1</version>
+        <version>${maven-source-plugin.version}</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -210,7 +210,7 @@
 
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.4.0</version>
+        <version>3.4.1</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -224,7 +224,7 @@
 
       <plugin>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0-M2</version>
+        <version>3.0.0</version>
         <executions>
           <execution>
             <id>deploy</id>


### PR DESCRIPTION
Upgrading jackson from 2.13.3 to 2.14.0 fixes Denial of Service (DoS):

https://nvd.nist.gov/vuln/detail/CVE-2022-42003
https://nvd.nist.gov/vuln/detail/CVE-2022-42004

All other dependencies are upgraded.

One exception: Upgrading HttpCore from 4.x to 5.x will be handled in https://issues.folio.org/browse/EDGAPIUTL-11
because it requires code changes.
