### PR TITLE
EDGAPIUTL-15: Change in TokenCache for UserToken for RTR and Java 17 upgradation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
 buildMvn {
   mvnDeploy = 'yes'
-  buildNode = 'jenkins-agent-java11'
+  buildNode = 'jenkins-agent-java17'
 }

--- a/pom.xml
+++ b/pom.xml
@@ -194,6 +194,20 @@
       </plugin>
 
       <plugin>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>${maven-source-plugin.version}</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <phase>deploy</phase>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>3.4.1</version>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <description>Common/Shared Edge API utilities for edge-common and edge-common-spring</description>
 
   <properties>
-    <java.version>11</java.version>
+    <java.version>17</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <vault.version>5.1.0</vault.version>
     <aws-java-sdk.version>1.12.341</aws-java-sdk.version>
@@ -21,7 +21,7 @@
     <awaitility.version>4.2.0</awaitility.version>
     <junit.version>4.13.2</junit.version>
     <wiremock.version>2.35.0</wiremock.version>
-    <mockito.version>4.5.1</mockito.version>
+    <mockito.version>4.6.1</mockito.version>
     <commons-lang3.version>3.12.0</commons-lang3.version>
   </properties>
 
@@ -45,6 +45,11 @@
   </dependencyManagement>
 
   <dependencies>
+    <dependency>
+      <groupId>org.folio</groupId>
+      <artifactId>folio-spring-system-user</artifactId>
+      <version>7.2.0-SNAPSHOT</version>
+    </dependency>
     <!-- we use log4j as our logging implementation -->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
@@ -114,7 +119,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.10.1</version>
         <configuration>
-          <release>11</release>
+          <release>17</release>
         </configuration>
       </plugin>
       <plugin>
@@ -186,20 +191,6 @@
           <pushChanges>false</pushChanges>
           <localCheckout>true</localCheckout>
         </configuration>
-      </plugin>
-
-      <plugin>
-        <artifactId>maven-source-plugin</artifactId>
-        <version>${maven-source-plugin.version}</version>
-        <executions>
-          <execution>
-            <id>attach-sources</id>
-            <phase>deploy</phase>
-            <goals>
-              <goal>jar-no-fork</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
 
       <plugin>

--- a/src/main/java/org/folio/edge/api/utils/cache/Cache.java
+++ b/src/main/java/org/folio/edge/api/utils/cache/Cache.java
@@ -1,8 +1,9 @@
 package org.folio.edge.api.utils.cache;
 
-import java.util.LinkedHashMap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import java.util.LinkedHashMap;
 
 /**
  * A general purpose cache storing entries with a set TTL,
@@ -41,10 +42,7 @@ public class Cache<T> {
   }
 
   public void remove(String key) {
-    CacheValue<T> cached = storage.get(key);
-    if (cached != null) {
-      storage.remove(key);
-    }
+    storage.remove(key);
   }
 
   public CacheValue<T> put(String key, T value) {

--- a/src/main/java/org/folio/edge/api/utils/cache/Cache.java
+++ b/src/main/java/org/folio/edge/api/utils/cache/Cache.java
@@ -40,6 +40,13 @@ public class Cache<T> {
     }
   }
 
+  public void remove(String key) {
+    CacheValue<T> cached = storage.get(key);
+    if (cached != null) {
+      storage.remove(key);
+    }
+  }
+
   public CacheValue<T> put(String key, T value) {
     // Double-checked locking...
     CacheValue<T> cached = storage.get(key);

--- a/src/main/java/org/folio/edge/api/utils/cache/TokenCache.java
+++ b/src/main/java/org/folio/edge/api/utils/cache/TokenCache.java
@@ -4,6 +4,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.edge.api.utils.cache.Cache.Builder;
 import org.folio.edge.api.utils.cache.Cache.CacheValue;
+import org.folio.spring.model.UserToken;
 
 /**
  * A cache for storing (JWT) tokens. For now, cache entries are have a set TTL,
@@ -16,13 +17,13 @@ public class TokenCache {
 
   private static TokenCache instance = null;
 
-  private final Cache<String> cache;
+  private final Cache<UserToken> cache;
 
   private TokenCache(long ttl, long nullTokenTtl, int capacity) {
     logger.info("Using TTL: {}", ttl);
     logger.info("Using null token TTL: {}", nullTokenTtl);
     logger.info("Using capacity: {}", capacity);
-    cache = new Builder<String>()
+    cache = new Builder<UserToken>()
       .withTTL(ttl)
       .withNullValueTTL(nullTokenTtl)
       .withCapacity(capacity)
@@ -30,7 +31,7 @@ public class TokenCache {
   }
 
   /**
-   * Get the TokenCache singleton. the singleton must be initialize before
+   * Get the TokenCache singleton. the singleton must be initialized before
    * calling this method.
    *
    * See {@link #initialize(long, long, int)}
@@ -63,11 +64,11 @@ public class TokenCache {
     return instance;
   }
 
-  public String get(String clientId, String tenant, String username) {
+  public UserToken get(String clientId, String tenant, String username) {
     return cache.get(computeKey(clientId, tenant, username));
   }
 
-  public CacheValue<String> put(String clientId, String tenant, String username, String token) {
+  public CacheValue<UserToken> put(String clientId, String tenant, String username, UserToken token) {
     return cache.put(computeKey(clientId, tenant, username), token);
   }
 

--- a/src/main/java/org/folio/edge/api/utils/cache/TokenCache.java
+++ b/src/main/java/org/folio/edge/api/utils/cache/TokenCache.java
@@ -72,6 +72,10 @@ public class TokenCache {
     return cache.put(computeKey(clientId, tenant, username), token);
   }
 
+  public void invalidate(String clientId, String tenant, String username) {
+    cache.remove(computeKey(clientId, tenant, username));
+  }
+
   private String computeKey(String clientId, String tenant, String username) {
     return String.format("%s:%s:%s", clientId, tenant, username);
   }

--- a/src/test/java/org/folio/edge/api/utils/cache/CacheTest.java
+++ b/src/test/java/org/folio/edge/api/utils/cache/CacheTest.java
@@ -53,6 +53,23 @@ public class CacheTest {
   }
 
   @Test
+  public void testPutRemovePutGet() throws Exception {
+    logger.info("=== Test basic functionality (Put, Remove, Put, Get)... ===");
+
+    // basic Put
+    cache.put(key, 1L);
+    assertEquals(1L, cache.get(key).longValue());
+
+    // Remove
+    cache.remove(key);
+    assertNull(cache.get(key));
+
+    // Put and Get
+    cache.put(key, 2L);
+    assertEquals(2L, cache.get(key).longValue());
+  }
+
+  @Test
   public void testNoOverwrite() throws Exception {
     logger.info("=== Test entries aren't overwritten... ===");
 

--- a/src/test/java/org/folio/edge/api/utils/cache/TokenCacheTest.java
+++ b/src/test/java/org/folio/edge/api/utils/cache/TokenCacheTest.java
@@ -77,6 +77,20 @@ public class TokenCacheTest {
   }
 
   @Test
+  public void testPutInvalidate() throws Exception {
+    logger.info("=== Test basic functionality (Get, Put, Get)... ===");
+
+    TokenCache cache = TokenCache.getInstance();
+
+    // basic functionality
+    cache.put(clientId, tenant, user, val);
+    assertEquals(val, cache.get(clientId, tenant, user));
+
+    cache.invalidate(clientId, tenant, user);
+    assertNull(cache.get(clientId, tenant, user));
+  }
+
+  @Test
   public void testNoOverwrite() throws Exception {
     logger.info("=== Test entries aren't overwritten... ===");
 


### PR DESCRIPTION
[EDGAPIUTL-15](https://issues.folio.org/browse/EDGAPIUTL-15) : Change in TokenCache for UserToken for RTR

## Purpose
 edge-common-spring is using TokenCache of edge-api-utils. This TokenCache is not being used anywhere.
 So far it is maintaining token in the form of string (Cache<String>). As per the RTR change implementation in edge-common-spring, change has been made here to store UserToken which contains token with its expiration time. It's a dependent change.

## Approach
 Change TokenCache to manage Cache<UserToken> instead of Cache<String>. Included common-library folio-spring-system-user to include UserToken.

 - Does this PR meet or exceed the expected quality standards?
   - [X] Code coverage on new code is 80% or greater
   - [X] Duplications on new code is 3% or less
   - [X] There are no major code smells or security issues