### PR TITLE
EDGAPIUTL-17: Upgrade aws-java-sdk, folio-spring-base, spring boot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,12 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
       <version>3.1.8</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <!-- we use log4j as our logging implementation -->
     <dependency>


### PR DESCRIPTION
https://issues.folio.org/browse/EDGAPIUTL-17

Upgrade aws-java-sdk from 1.12.341 to 1.12.638. This removes the dependency and usage of software.amazon.ion:ion-java@1.0.2 that has an Allocation of Resources Without Limits or Throttling vulnerability:

* https://nvd.nist.gov/vuln/detail/CVE-2024-21634
* https://github.com/aws/aws-sdk-java/issues/3077#issuecomment-1896650670

Upgrade spring-boot-starter-web from 3.1.1 to 3.1.8.

The spring-boot-starter-web upgrade indirectly upgrades spring-web from 6.0.10 to 6.0.16 fixing Denial of Service (DoS):

* https://nvd.nist.gov/vuln/detail/CVE-2023-34053

The spring-boot-starter-web upgrade indirectly upgrades tomcat-embed-core from 10.1.10 to 10.1.18 fixing multiple vulnerabilities:

* Denial of Service (DoS): https://nvd.nist.gov/vuln/detail/CVE-2023-44487
* HTTP request smuggling: https://nvd.nist.gov/vuln/detail/CVE-2023-46589
* Access Restriction Bypass: https://nvd.nist.gov/vuln/detail/CVE-2023-41080
* HTTP request smuggling: https://nvd.nist.gov/vuln/detail/CVE-2023-45648
* Incomplete Cleanup: https://nvd.nist.gov/vuln/detail/CVE-2023-42795

Upgrade folio-spring-base from 7.2.0 to 7.2.2 to match the spring-boot-starter-web upgrade.