### PR TITLE
EDGAPIUTL-20: Quesnelia deps: folio-spring-support 8.1.0, aws 1.12.671, …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,19 +19,19 @@
   <properties>
     <java.version>17</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vault.version>5.1.0</vault.version>
-    <aws-java-sdk.version>1.12.638</aws-java-sdk.version>
-    <versions-maven-plugin.version>2.13.0</versions-maven-plugin.version>
-    <maven-enforcer-plugin.version>3.1.0</maven-enforcer-plugin.version>
-    <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
-    <build-helper-maven-plugin.version>3.3.0</build-helper-maven-plugin.version>
-    <maven-release-plugin.version>3.0.0-M7</maven-release-plugin.version>
+    <vault.version>6.2.0</vault.version>
+    <aws-java-sdk.version>1.12.671</aws-java-sdk.version>
+    <versions-maven-plugin.version>2.16.2</versions-maven-plugin.version>
+    <maven-enforcer-plugin.version>3.4.1</maven-enforcer-plugin.version>
+    <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
+    <build-helper-maven-plugin.version>3.5.0</build-helper-maven-plugin.version>
+    <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
     <awaitility.version>4.2.0</awaitility.version>
     <junit.version>4.13.2</junit.version>
-    <wiremock.version>2.35.0</wiremock.version>
-    <mockito.version>4.6.1</mockito.version>
-    <commons-lang3.version>3.12.0</commons-lang3.version>
-    <folio-spring-base.version>7.2.2</folio-spring-base.version>
+    <wiremock.version>3.4.2</wiremock.version>
+    <mockito.version>5.11.0</mockito.version>
+    <commons-lang3.version>3.14.0</commons-lang3.version>
+    <folio-spring-base.version>8.1.0</folio-spring-base.version>
   </properties>
 
   <dependencyManagement>
@@ -39,14 +39,14 @@
       <dependency>
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
-        <version>2.14.0</version>
+        <version>2.16.1</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.19.0</version>
+        <version>2.23.0</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -58,18 +58,6 @@
       <groupId>org.folio</groupId>
       <artifactId>folio-spring-system-user</artifactId>
       <version>${folio-spring-base.version}</version>
-    </dependency>
-    <!-- remove spring-boot-starter-web when folio-spring-system-user ships with spring-boot-starter-web >= 3.1.8 -->
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-web</artifactId>
-      <version>3.1.8</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.springframework.boot</groupId>
-          <artifactId>spring-boot-starter-logging</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <!-- we use log4j as our logging implementation -->
     <dependency>
@@ -86,7 +74,7 @@
     </dependency>
     <!-- Only needed for VaultStore -->
     <dependency>
-      <groupId>com.bettercloud</groupId>
+      <groupId>io.github.jopenlibs</groupId>
       <artifactId>vault-java-driver</artifactId>
       <version>${vault.version}</version>
     </dependency>
@@ -126,8 +114,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8-standalone</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock-standalone</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>
@@ -138,7 +126,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.10.1</version>
+        <version>3.12.1</version>
         <configuration>
           <release>17</release>
         </configuration>
@@ -230,11 +218,11 @@
 
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.4.1</version>
+        <version>3.6.3</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
-            <phase>deploy</phase>
+            <phase>verify</phase>
             <goals>
               <goal>jar</goal>
             </goals>
@@ -244,7 +232,7 @@
 
       <plugin>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.1</version>
         <executions>
           <execution>
             <id>deploy</id>

--- a/src/test/java/org/folio/edge/api/utils/util/ApiKeyHelperTest.java
+++ b/src/test/java/org/folio/edge/api/utils/util/ApiKeyHelperTest.java
@@ -14,7 +14,7 @@ import java.util.List;
 import org.folio.edge.api.utils.util.ApiKeyHelper.ApiKeySource;
 import org.junit.Test;
 import org.mockito.Mockito;
-import wiremock.javax.servlet.http.HttpServletRequest;
+import wiremock.jakarta.servlet.http.HttpServletRequest;
 
 public class ApiKeyHelperTest {
 


### PR DESCRIPTION
Upgrade vault from 5.1.0 to 6.2.0.
Upgrade aws-java-sdk from 1.12.638 to 1.12.671.
Upgrade commons-lang3 from 3.12.0 to 3.14.0.
Upgrade folio-spring-base from 7.2.2 to 8.1.0.
Upgrade jackson from 2.14.0 to 2.16.1.
Upgrade log4j from 2.19.0 to 2.23.0.

Also upgrade maven plugins and test dependencies.

https://folio-org.atlassian.net/browse/EDGAPIUTL-20

## Purpose
Upgrade dependencies for Quesnelia.

## Approach
Version from https://folio-org.atlassian.net/wiki/spaces/TC/pages/5056746/Quesnelia
or latest production version.

## Pre-Merge Checklist:
 Before merging this PR, please go through the following list and take appropriate actions.

 - Does this PR meet or exceed the expected quality standards?
   - [x] Code coverage on new code is 80% or greater
   - [x] Duplications on new code is 3% or less
   - [x] There are no major code smells or security issues
 - Does this introduce breaking changes?
   - [x] There are no breaking changes in this PR.

 While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
