### PR TITLE
EDGAPIUTL-24: not found: com.bettercloud.vault.VaultException

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@ Quesnelia release with dependency upgrades.
 ### Technical tasks
 * [EDGAPIUTL-20](https://folio-org.atlassian.net/browse/EDGAPIUTL-20) Quesnelia dependency upgrades: folio-spring-support 8.1.0, aws 1.12.671, vault 6.2.0, …
 
+The vault artifact group and package has changed: In pom.xml and Java code replace `com.bettercloud` with `io.github.jopenlibs`.
+
 ## 11/10/2023 v1.3.0 - Released
 This release includes changes in token cache for user token
 

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,13 @@
       <groupId>org.folio</groupId>
       <artifactId>folio-spring-system-user</artifactId>
       <version>${folio-spring-base.version}</version>
+      <exclusions>
+        <exclusion>
+          <!-- circular dependency: https://folio-org.atlassian.net/browse/FOLSPRINGS-146 -->
+          <groupId>org.folio</groupId>
+          <artifactId>edge-api-utils</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <!-- we use log4j as our logging implementation -->
     <dependency>

--- a/src/main/java/org/folio/edge/api/utils/security/VaultStore.java
+++ b/src/main/java/org/folio/edge/api/utils/security/VaultStore.java
@@ -1,9 +1,9 @@
 package org.folio.edge.api.utils.security;
 
-import com.bettercloud.vault.SslConfig;
-import com.bettercloud.vault.Vault;
-import com.bettercloud.vault.VaultConfig;
-import com.bettercloud.vault.VaultException;
+import io.github.jopenlibs.vault.SslConfig;
+import io.github.jopenlibs.vault.Vault;
+import io.github.jopenlibs.vault.VaultConfig;
+import io.github.jopenlibs.vault.VaultException;
 import java.io.File;
 import java.util.Properties;
 import org.apache.logging.log4j.LogManager;
@@ -63,7 +63,7 @@ public class VaultStore extends SecureStore {
         config.sslConfig(sslConfig);
       }
 
-      vault = new Vault(config.build());
+      vault = Vault.create(config.build());
     } catch (VaultException e) {
       logger.error("Failed to initialize: ", e);
     }

--- a/src/test/java/org/folio/edge/api/utils/security/VaultStoreTest.java
+++ b/src/test/java/org/folio/edge/api/utils/security/VaultStoreTest.java
@@ -5,10 +5,10 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.bettercloud.vault.Vault;
-import com.bettercloud.vault.api.Logical;
-import com.bettercloud.vault.response.LogicalResponse;
-import com.bettercloud.vault.rest.RestResponse;
+import io.github.jopenlibs.vault.Vault;
+import io.github.jopenlibs.vault.api.Logical;
+import io.github.jopenlibs.vault.response.LogicalResponse;
+import io.github.jopenlibs.vault.rest.RestResponse;
 import java.util.Properties;
 import org.folio.edge.api.utils.security.SecureStore.NotFoundException;
 import org.junit.Before;


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/EDGAPIUTL-24

ClassNotFoundException: com.bettercloud.vault.VaultException

```
java.lang.NoClassDefFoundError: com/bettercloud/vault/VaultException
	at org.folio.edge.api.utils.security.SecureStoreFactory.getSecureStore(SecureStoreFactory.java:23)
```

This is caused by the circular dependency folio-spring-system-user ↔︎ edge-api-utils.

Use `<exclusions>` in pom.xml and switch to the new Vault package name. Mention the change in the NEWS.