### PR TITLE
Configure approved SecureRandom in FIPS mode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
     <mockito.version>5.11.0</mockito.version>
     <commons-lang3.version>3.14.0</commons-lang3.version>
     <folio-spring-base.version>8.1.0</folio-spring-base.version>
+    <folio-tls-utils.version>1.5.2-SNAPSHOT</folio-tls-utils.version>
   </properties>
 
   <dependencyManagement>
@@ -100,6 +101,11 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>${commons-lang3.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.folio</groupId>
+      <artifactId>folio-tls-utils</artifactId>
+      <version>${folio-tls-utils.version}</version>
     </dependency>
     <!-- Test dependencies -->
     <dependency>


### PR DESCRIPTION
## Purpose
When working in the strict FIPS mode only approved SecureRandom instances may be used.

## Approach
When creating AwsParamStore, AWSSimpleSystemsManagementClientBuilder must be configured with the appropriate SecureRandom instance.
