### PR TITLE
EDGAPIUTL-28: Fix vulns: folio-spring-base 8.1.2, folio-tls-utils 1.5.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,8 @@
     <wiremock.version>3.4.2</wiremock.version>
     <mockito.version>5.11.0</mockito.version>
     <commons-lang3.version>3.14.0</commons-lang3.version>
-    <folio-spring-base.version>8.1.0</folio-spring-base.version>
-    <folio-tls-utils.version>1.5.6</folio-tls-utils.version>
+    <folio-spring-base.version>8.1.2</folio-spring-base.version>
+    <folio-tls-utils.version>1.5.7</folio-tls-utils.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/EDGAPIUTL-28

## Purpose
Fix security vulnerabilities in Quesnelia:

## Approach
Upgrade folio-spring-base from 8.1.0 to 8.1.2.

Upgrade  folio-tls-utils from 1.5.6 to 1.5.7.