### PR TITLE
EDGAPIUTL-37: Migrate Jackson from 2 to 3 (tools.jackson.core)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,9 +37,9 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>com.fasterxml.jackson</groupId>
+        <groupId>tools.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
-        <version>2.21.0</version>
+        <version>3.1.0</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -92,7 +92,7 @@
       <version>${aws-java-sdk.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <groupId>tools.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-xml</artifactId>
     </dependency>
     <!-- Other dependencies -->

--- a/src/main/java/org/folio/edge/api/utils/Mappers.java
+++ b/src/main/java/org/folio/edge/api/utils/Mappers.java
@@ -1,24 +1,27 @@
 package org.folio.edge.api.utils;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import java.text.SimpleDateFormat;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.dataformat.xml.XmlMapper;
 
-public class Mappers {
+/**
+ * Provide {@link #jsonMapper} and {@link #xmlMapper}.
+ */
+public final class Mappers {
   public static final String XML_PROLOG = "<?xml version='1.0' encoding='UTF-8'?>\n";
 
   public static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
 
-  public static final ObjectMapper jsonMapper = new ObjectMapper()
+  public static final JsonMapper jsonMapper = JsonMapper.builder()
     .enable(SerializationFeature.INDENT_OUTPUT)
-    .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-    .setDateFormat(new SimpleDateFormat(DATE_FORMAT));
+    .defaultDateFormat(new SimpleDateFormat(DATE_FORMAT))
+    .build();
 
-  public static final XmlMapper xmlMapper = (XmlMapper) new XmlMapper()
+  public static final XmlMapper xmlMapper = XmlMapper.builder()
     .enable(SerializationFeature.INDENT_OUTPUT)
-    .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-    .setDateFormat(new SimpleDateFormat(DATE_FORMAT));
+    .defaultDateFormat(new SimpleDateFormat(DATE_FORMAT))
+    .build();
 
   private Mappers() {
 

--- a/src/main/java/org/folio/edge/api/utils/util/ApiKeyParser.java
+++ b/src/main/java/org/folio/edge/api/utils/util/ApiKeyParser.java
@@ -1,9 +1,9 @@
 package org.folio.edge.api.utils.util;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Base64;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.edge.api.utils.model.ClientInfo;
+import tools.jackson.databind.json.JsonMapper;
 
 public class ApiKeyParser {
 
@@ -15,8 +15,7 @@ public class ApiKeyParser {
 
     try {
       String decoded = new String(Base64.getUrlDecoder().decode(apiKey.getBytes()));
-      ObjectMapper mapper = new ObjectMapper();
-      clientInfo = mapper.readValue(decoded, ClientInfo.class);
+      clientInfo = JsonMapper.shared().readValue(decoded, ClientInfo.class);
     } catch (Exception var4) {
       throw new MalformedApiKeyException("Failed to parse apiKey to retrieve client info", var4);
     }

--- a/src/test/java/org/folio/edge/api/utils/MappersTest.java
+++ b/src/test/java/org/folio/edge/api/utils/MappersTest.java
@@ -1,14 +1,16 @@
 package org.folio.edge.api.utils;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
+import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.Test;
+import tools.jackson.databind.json.JsonMapper;
 
 public class MappersTest {
 
@@ -17,8 +19,8 @@ public class MappersTest {
     String key = "foo";
     String value = "bar";
 
-    ObjectMapper mapper = new ObjectMapper();
-    ObjectNode node = mapper.createObjectNode();
+    var mapper = JsonMapper.shared();
+    var node = mapper.createObjectNode();
     node.put(key, value);
 
     String json = node.toPrettyString();
@@ -54,15 +56,24 @@ public class MappersTest {
     assertEquals(obj.b, asObj.b);
   }
 
-  @JacksonXmlRootElement(localName = "test")
+  @Test
+  public void testJsonDate() {
+    var datestring1 = "\"1999-12-31T23:59:58.765Z\"";
+    var date = Mappers.jsonMapper.readValue(datestring1, OffsetDateTime.class);
+    assertThat(date.toString(), is("1999-12-31T23:59:58.765Z"));
+    var datestring2 = Mappers.jsonMapper.writeValueAsString(date);
+    assertThat(datestring2, is(datestring1));
+  }
+
+  @JsonRootName(value = "test")
   public static class TestObject {
 
-    @JacksonXmlProperty(localName = "a")
+    @JsonProperty(value = "a")
     private String a;
-    @JacksonXmlProperty(localName = "b")
+    @JsonProperty(value = "b")
     private String b;
 
-    public TestObject(@JacksonXmlProperty(localName = "a") String a, @JacksonXmlProperty(localName = "b") String b) {
+    public TestObject(@JsonProperty(value = "a") String a, @JsonProperty(value = "b") String b) {
       this.a = a;
       this.b = b;
     }

--- a/src/test/java/org/folio/edge/api/utils/util/ApiKeyParserTest.java
+++ b/src/test/java/org/folio/edge/api/utils/util/ApiKeyParserTest.java
@@ -2,12 +2,12 @@ package org.folio.edge.api.utils.util;
 
 import static org.junit.Assert.assertEquals;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Base64;
 import org.folio.edge.api.utils.model.ClientInfo;
 import org.folio.edge.api.utils.util.ApiKeyParser.MalformedApiKeyException;
 import org.junit.Assert;
 import org.junit.Test;
+import tools.jackson.databind.json.JsonMapper;
 
 public class ApiKeyParserTest {
 
@@ -16,7 +16,7 @@ public class ApiKeyParserTest {
   public static final String USERNAME = "diku";
   public static final String API_KEY = "eyJzIjoiZ0szc0RWZ3labCIsInQiOiJkaWt1IiwidSI6ImRpa3UifQ==";
   public static final String BAD_API_KEY = "broken";
-  ObjectMapper objectMapper = new ObjectMapper();
+  JsonMapper objectMapper = JsonMapper.shared();
 
 
   @Test


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/EDGAPIUTL-37

## Purpose
For Trillium FOLIO uses a Spring Boot version that no longer depends on Jackson 2 (com.fasterxml.jackson) but on Jackson 3 (tools.jackson.core).

For consistency we use the same Jackson version in edge-api-utils.

3.1.x is an LTS version.

## Approach
Change pom.xml, import statements, and code where needed.

## Pre-Merge Checklist:
 Before merging this PR, please go through the following list and take appropriate actions.

 - Does this PR meet or exceed the expected quality standards?
   - [x] Code coverage on new code is 80% or greater
   - [x] Duplications on new code is 3% or less
   - [x] There are no major code smells or security issues
 - Does this introduce breaking changes?
   - Yes, intended breaking change when a Jackson feature is used where API has changed.
   - edge-common-spring has already migrated to Jackson 3: https://github.com/search?q=repo%3Afolio-org%2Fedge-common-spring%20jackson&type=code