### PR TITLE
EDGAPIUTL-38: Bump tomcat, jackson, netty, log4j, spring boot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <java.version>21</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <vault.version>6.2.1</vault.version>
-    <aws-java-sdk.version>2.41.27</aws-java-sdk.version>
+    <aws-java-sdk.version>2.42.41</aws-java-sdk.version>
     <versions-maven-plugin.version>2.21.0</versions-maven-plugin.version>
     <maven-enforcer-plugin.version>3.6.2</maven-enforcer-plugin.version>
     <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
@@ -37,18 +37,11 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>tools.jackson</groupId>
-        <artifactId>jackson-bom</artifactId>
-        <version>3.1.0</version>
-        <scope>import</scope>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>4.0.6</version>
         <type>pom</type>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-bom</artifactId>
-        <version>2.25.3</version>
         <scope>import</scope>
-        <type>pom</type>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/EDGAPIUTL-38

## Purpose

Fix multiple security vulnerabilities:

* https://www.cve.org/CVERecord?id=CVE-2026-34500 – tomcat
* https://app.snyk.io/vuln/SNYK-JAVA-TOOLSJACKSONCORE-15907550 – jackson
* https://www.cve.org/CVERecord?id=CVE-2026-33871 – netty
* https://www.cve.org/CVERecord?id=CVE-2026-34480 – log4j
* https://www.cve.org/CVERecord?id=CVE-2026-34478 – log4j
* https://www.cve.org/CVERecord?id=CVE-2026-40973 – spring boot
* https://www.cve.org/CVERecord?id=CVE-2026-34477 – log4j
* https://www.cve.org/CVERecord?id=CVE-2026-40977 – spring boot
* https://www.cve.org/CVERecord?id=CVE-2026-40975 – spring boot
* https://www.cve.org/CVERecord?id=CVE-2026-40974 – spring boot

## Approach
Bump the spring boot dependencies from 4.0.5 to 4.0.6 and aws ssm from 2.41.27 to 2.42.41.

The spring boot bump transitively bumps tomcat, jackson and log4j to a fixed version.

## Pre-Merge Checklist:
 Before merging this PR, please go through the following list and take appropriate actions.

 - Does this PR meet or exceed the expected quality standards?
   - [x] Code coverage on new code is 80% or greater
   - [x] Duplications on new code is 3% or less
   - [x] There are no major code smells or security issues
 - Does this introduce breaking changes?
   - [x] There are no breaking changes in this PR.