### PR TITLE
EDGAPIUTL-39: Add cause to AuthorizationException and PropertiesUtil

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,10 +26,7 @@
     <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
     <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
     <maven-release-plugin.version>3.3.1</maven-release-plugin.version>
-    <awaitility.version>4.3.0</awaitility.version>
-    <junit.version>4.13.2</junit.version>
     <wiremock.version>3.13.2</wiremock.version>
-    <mockito.version>5.21.0</mockito.version>
     <folio-spring-base.version>10.0.0</folio-spring-base.version>
     <folio-tls-utils.version>4.0.0</folio-tls-utils.version>
   </properties>
@@ -98,19 +95,26 @@
     <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
-      <version>${awaitility.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>${mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/org/folio/edge/api/utils/exception/AuthorizationException.java
+++ b/src/main/java/org/folio/edge/api/utils/exception/AuthorizationException.java
@@ -1,12 +1,16 @@
 package org.folio.edge.api.utils.exception;
 
 /**
- * Specific exception for handlig edge-authorization process
+ * Specific exception for handling edge-authorization process
  */
 public class AuthorizationException extends RuntimeException {
 
   public AuthorizationException(String message) {
     super(message);
+  }
+
+  public AuthorizationException(String message, Throwable cause) {
+    super(message, cause);
   }
 }
 

--- a/src/main/java/org/folio/edge/api/utils/util/PropertiesUtil.java
+++ b/src/main/java/org/folio/edge/api/utils/util/PropertiesUtil.java
@@ -36,7 +36,7 @@ public class PropertiesUtil {
           logger.info("Successfully loaded properties from: {}", secureStorePropFile);
         }
       } catch (Exception e) {
-        throw new AuthorizationException("Failed to load secure store properties");
+        throw new AuthorizationException("Failed to load secure store properties", e);
       }
     } else {
       logger.warn("No secure store properties file specified. Using defaults");

--- a/src/test/java/org/folio/edge/api/utils/exception/AuthorizationExceptionTest.java
+++ b/src/test/java/org/folio/edge/api/utils/exception/AuthorizationExceptionTest.java
@@ -1,0 +1,24 @@
+package org.folio.edge.api.utils.exception;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.theInstance;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+class AuthorizationExceptionTest {
+
+  @Test
+  void message() {
+    var e = new AuthorizationException("hi");
+    assertThat(e.getMessage(), is("hi"));
+  }
+
+  @Test
+  void messageAndCause() {
+    var cause = new IllegalArgumentException("bar");
+    var e = new AuthorizationException("foo", cause);
+    assertThat(e.getMessage(), is("foo"));
+    assertThat(e.getCause(), is(theInstance(cause)));
+  }
+}


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/EDGAPIUTL-39

## Purpose
When throwing an AuthorizationException the cause if any should be stored so that it can be logged.

Currently the cause is suppressed.

## Approach

Add the AuthorizationException(String message, Throwable cause) constructor.

Use the new constructor in PropertiesUtil.

## Learning
When creating a custom Exception class always add a constructor with cause.

## Pre-Merge Checklist:
 Before merging this PR, please go through the following list and take appropriate actions.

 - Does this PR meet or exceed the expected quality standards?
   - [x] Code coverage on new code is 80% or greater
   - [x] Duplications on new code is 3% or less
   - [x] There are no major code smells or security issues
 - Does this introduce breaking changes?
   - [x] There are no breaking changes in this PR.